### PR TITLE
send the prerender-status-code

### DIFF
--- a/lib/fileCompressedCache.js
+++ b/lib/fileCompressedCache.js
@@ -37,7 +37,8 @@ module.exports = function(config){
                     console.log(now.toDateString() + ' ' + now.toTimeString() + ' cache hit');
                     zlib.inflate(result, function(error, result) {
                         if (!error) {
-                            res.send(200, result);
+                            match = /<meta[^<>]*(?:name=['"]prerender-status-code['"][^<>]*content=['"]([0-9]{3})['"]|content=['"]([0-9]{3})['"][^<>]*name=['"]prerender-status-code['"])[^<>]*>/i.exec(String.fromCharCode.apply(null, result));
+                            res.send(match[1] || match[2] || 200, result);
                         }
                     });
                 } else {


### PR DESCRIPTION
Greetings,

This extra line of code check if there is a prerender-status-code in the cached file and send it instead of the default 200.
It fixed my problem where the prerender-status-code is 404 in the cached file but it return 200 to the crawler

Best Regards,
Ahmed